### PR TITLE
🏗🐃 VR Fixes and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Theoretically, it should work with Rift, Windows MR, etc, as long as you follow 
   - Seems like not everything has loaded (sky is white, main menu is missing, etc.)
   - The "Click to use VR cursor" prompt showing up in VR
 - The screen is just...white.
-  - If you're on a tablet/mobile phone, this is probably a good thing. This takes a bit longer to load on mobile devices, so give it a minute.
   - If it still hasn't loaded, make sure your browser [supports A-Frame.](https://aframe.io/docs/0.7.0/introduction/vr-headsets-and-webvr-browsers.html#which-browsers-does-a-frame-support)
 - Are those cones on the side of the road supposed to be streetlights?
   - If the streetlights aren't loading, [clearing your browser cache](http://www.refreshyourcache.com/en/home/) might help.
@@ -60,9 +59,12 @@ Theoretically, it should work with Rift, Windows MR, etc, as long as you follow 
     - Find your browser and call end process on it. Restart SteamVR.
     - If unsuccessful, close browsers and restart Steam.
     - Open browsers only after SteamVR has started up again.
-  - Loading forever (from within VR, even if display shows up on desktop):
+  - Loading forever (from within VR, display may be working, glitched or frozen on desktop):
     - Refresh page and try again.
-    - If this does not work, close browser window, reboot SteamVR, and re-open window.
+    - If that doesn't help, restart your browser.
+    - If that didn't help either, close browser window, reboot SteamVR, then re-open browser.
+  - Position seems way off (You should be in the center of the road, which is matched to the actual ground)
+    - Exit browser, make sure your SteamVR home floor is correctly placed, then re-open browser.
 - Performance:
   - Displaying the webpage on both your VR headset and desktop will hurt performance. Minimize the window on desktop or open another random tab instead.
 

--- a/components/includes.js
+++ b/components/includes.js
@@ -243,7 +243,6 @@ function checkHasPositionalTracking () {
   var vrDisplay = getVRDisplay();
   if (isMobile() || isGearVR() || !vrDisplay) { return false; }
   var pos = vrDisplay.capabilities.hasPosition;
-  console.log("Found a VR with headset with positional: " + pos);
   return vrDisplay && pos;
 }
 

--- a/components/managers.js
+++ b/components/managers.js
@@ -1,4 +1,4 @@
-/* global AFRAME, THREE, beat, bind, Uint8Array, isMobile, checkHeadsetConnected */
+/* global AFRAME, THREE, beat, bind, Uint8Array, isMobile, checkHeadsetConnected, checkHasPositionalTracking */
 
 var debug = false;
 
@@ -451,11 +451,10 @@ AFRAME.registerComponent('camera-manager', {
   init: function () {
     var el = this.el;
     
-    // Use regular look controls for VR. Custom look controls don't work. Codebase is inconsistent.
+    // Use regular look controls for VR. Custom look controls don't work.
     if (el.getAttribute('id') == 'camera') {
       if (checkHeadsetConnected()) {
-        el.setAttribute('look-controls','');
-        el.setAttribute('position', '0 0.25 27');
+        el.setAttribute('my-look-controls','');
         if (isMobile()) {
           el.setAttribute('position', '0 1.6 25');
         }
@@ -706,7 +705,7 @@ AFRAME.registerComponent('audio-react', {
       });
       if (data.stablebase) {
         var curpos = this.el.getAttribute('position');
-        var sety = this.firstpos + val/2;
+        var sety = this.firstpos + val/2 - 0.5;
         this.el.setAttribute('position', {
           x: curpos.x,
           // TODO: this may not work with moving objects, will always reset y position to initial

--- a/components/rng.js
+++ b/components/rng.js
@@ -462,7 +462,8 @@ AFRAME.registerComponent('rng-building-pulse', {
                           + "; width: " + width + "; height: " + height + "; winwidth: 0.5; winheight: 0.65; fog: true";
     var center = document.createElement('a-entity');
     center.setAttribute('rng-building-shader', buildingAttrs);
-    center.setAttribute('scale', "0.99 0.99 0.99");
+    center.setAttribute('scale', "1.01 1.01 1.01");
+    center.setAttribute('position', '0 -0.1 0');
     this.el.appendChild(center);
     
     var front = document.createElement('a-entity');
@@ -883,6 +884,7 @@ AFRAME.registerComponent('rng-building-shader', {
           this.setAttribute("visible", true);
         });
       }
+      
       else if (data.action == 'lights') {
         this.el.addEventListener('beat', function () {
           var time = this.children[1].getObject3D('mesh').material.uniforms['timeMsec']['value'];
@@ -893,6 +895,11 @@ AFRAME.registerComponent('rng-building-shader', {
           color.y = nextcolor.g / 255;
           color.z = nextcolor.b / 255;
           this.children[1].getObject3D('mesh').material.uniforms['color2']['value'] = color;
+          /* Randomly slide in a direction (disabled due to motion sickness)
+          var slide = rng([0, 2, 4, 6, 8], '1 1 1 1 1');
+          this.children[1].getObject3D('mesh').material.uniforms['slide']['value'] = slide;
+          this.children[1].getObject3D('mesh').material.uniforms['colorslide']['value'] = slide;
+          this.children[1].getObject3D('mesh').material.uniforms['slidereverse']['value'] = rng([0, 1], '1 1');*/
         });
       }
       else if (data.action == 'portal') {
@@ -1271,11 +1278,12 @@ AFRAME.registerComponent('rng-building-snake', {
 AFRAME.registerComponent('rng-building-asteroid', {
   schema: {
     start: {default: 0},
+    height: {default: '4 1'},
   },
   init: function () {
     var rotations = ["0 0 0", "45 0 0", "0 0 45"];
     var scale = 1;
-    var height = rng([1, 2], '4 1');
+    var height = rng([1, 2], this.data.height);
     for (var i = 0; i < 3; i++) {
       var building = document.createElement('a-entity');
       building.setAttribute('rng-building-shader', "height: " + height + "; static: 1 0; colorstyle: 1 0 0 0; winheight: 0 0 1 0; winwidth: 0 1 0; color1: black; action: spaceship");
@@ -1313,10 +1321,11 @@ AFRAME.registerComponent('rng-asteroids', {
       var y = (Math.random() * 4000) - 2000;
       var z = (Math.random() * 4000) - 2000;
       var scale = 0;
+      var height = '4 1';
       
       var checkx = Math.abs(x); var checky = Math.abs(y); var checkz = Math.abs(z);
       // Special case put an asteroid right below camera
-      if (this.loadex == 0) {x = -6; y = 6; z = 0; scale = 1}
+      if (this.loadex == 0) {x = -10; y = 10; z = 0; scale = 1; height = '0 1'}
       // For the rest, make sure they aren't on a collision course with cam or nearby ships
       else {
         // Don't place an asteroid if it would collide with a ship
@@ -1335,7 +1344,7 @@ AFRAME.registerComponent('rng-asteroids', {
       var postr = x + " " + y + " " + z;
       var scalestr = scale + " " + scale + " " + scale;
       
-      building.setAttribute('rng-building-asteroid', 'start: ' + this.data.start);
+      building.setAttribute('rng-building-asteroid', 'start: ' + this.data.start + '; height: ' + height);
       building.setAttribute('position', postr);
       building.setAttribute('rotation', postr);
       building.setAttribute('allrotate', '');

--- a/components/worldbuilders.js
+++ b/components/worldbuilders.js
@@ -337,7 +337,7 @@ function colorCity(builder, data) {
     height *= width * Math.floor(1 + Math.random() * 3);
 
     var rngbuilding = document.createElement('a-entity');
-    var randtrigger = 169 + Math.floor(Math.random() * 20); // 151 If we want colors earlier
+    var randtrigger = 169 + Math.floor(Math.random() * 30); // 151 If we want colors earlier
     rngbuilding.setAttribute('rng-building-shader', "width: " + width + "; height: " + height + "; triggerbeat: " + randtrigger + "; action: lights"
                                + "; color1: #FFFF00; usecolor: 1 0; grow_slide: 1 1; static: 1 0; axis: 1 1; colorstyle: 1 0 0 0");
 
@@ -383,26 +383,17 @@ function movingCity(builder, data) {
   if (builder.x == 0 && builder.z == 4) {
     robostart = 82;
     jumpstart = 62;
-    type = 'robot';//rng([type, 'robot'], '0 1');
+    type = 'robot';
   }
   else if (builder.x == 0 && builder.z == 7) {
     robostart = 66;
     jumpstart = 48;
-    type = 'robot';//rng([type, 'robot'], '0 1');
+    type = 'robot';
   }
   // Find out whether the space will have a building if it doesn't have a robot
   else {
-    //console.log("a is " + (builder.x == 0));
-    //console.log("b is " + (builder.x == (builder.xmax - 1)));
-    if (builder.x == 0 || (builder.x == (builder.xmax - 1))) { // Edges have less, they're far away
-      if (rng([true, false], '1 2')) { // True means no building
+    if (rng([true, false], '1 2')) { // True means no building
         return; 
-      }
-    }
-    else {
-      if (rng([true, false], '1 2')) { // True means no building
-        return; 
-      }
     }
     // If we made it to here, there's no robot and we need a building. Time to pick a type.
     var type = rng(['arcy', 'arcx', 'flower', 'sine', 'pulse', 'split', 'dance'], '2 1 1 2 2 1 3');
@@ -479,11 +470,11 @@ function movingCity(builder, data) {
   }
   else if (type == 'robot') {
     builder.x = builder.xmax - 1;
-    var reverse = rng([true, false], '1 1');
-    rngbuilding.setAttribute('rng-building-robot', "color1: #ffff00; reverse: " + reverse + typestr + "; start: " + robostart);
+    this.reverse = !this.reverse;
+    rngbuilding.setAttribute('rng-building-robot', "color1: #ffff00; reverse: " + this.reverse + typestr + "; start: " + robostart);
     xoffset = 187;
     yrotation = 180;
-    if (reverse) {
+    if (this.reverse) {
       xoffset = -101.5;
       yrotation = 0;
     }

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <title>Road.</title>
     <meta name="description" content="Road.">
     <!-- Included components -->
-    <script src="https://rawgit.com/aframevr/aframe/4d90df5/dist/aframe-master.min.js"></script>
+    <script src="https://aframe.io/releases/0.7.0/aframe.min.js"></script>
     <script src="https://unpkg.com/aframe-animation-component@4.1.1/dist/aframe-animation-component.min.js"></script>
     <script src="https://npmcdn.com/aframe-event-set-component@3.0.1"></script>
     <script src="https://npmcdn.com/aframe-template-component@3.1.1"></script>
@@ -210,7 +210,7 @@
       </a-entity>
 
       <!-- Camera and children -->
-      <a-entity id="camera" camera="userHeight: 0.075; near: 0.25" position="0 0 25" look-controls
+      <a-entity id="camera" camera="userHeight: 0.075; near: 0.25" position="0 0.1 25" look-controls
                 camera-manager="speed: 12; stop: -2800; id: main" rotation="20 0 0">
         <a-entity id="analyser" audioanalyser="src: #side; enableBeatDetection: false;" ></a-entity>
         <a-entity music-manager="startpos: -50; showbeats: true"></a-entity>


### PR DESCRIPTION
Recent updates broke VR support. It's fixed now.

- Rolled back A-Frame version. It seems positional tracking cameras can't be moved using the same method that worked with previous A-Frame versions. Since I couldn't find any documentation on this and it breaks the video, for now the version will be rolled back.
- Other small tweaks to camera positioning
- README troubleshooting updates from testing
- Tweaks to adjust for updated visuals in VR (floating buildings, etc)
- Reversed robots are no longer RNG
- Various cleanup things
- Added then removed a feature to slide buildings in colorCity. Looked good in 2D, but ended up causing motion sickness in VR as it reduces consistency of visual cues.